### PR TITLE
Customize the color of highlighted paths. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,10 @@ Pass an array of data to overlay the data on the chart, masking the foreground.
 
 Clear the highlighting layer. This is equivalent to calling <a href="#parcoords_clear">parcoords.clear("highlight")</a>.
 
+
+Change coloring of the highlighted polylines. If *color* is a string, highlighted polylines will be rendered as that color. If *color* is a function, that function will be run for each data element and the polyline color will be the return value.
+If no *color* is specified, the highlighted polylines get the original coloring for foreground items.
+
 <a name="parcoords_interactive" href="#parcoords_interactive">#</a> parcoords.<b>interactive</b>()
 
 Activate interactive mode for use with a JavaScript console. The concept is that for each method that modifies a chart, everything that needs to happen to update the rendered chart will run automatically.

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Pass an array of data to overlay the data on the chart, masking the foreground.
 
 Clear the highlighting layer. This is equivalent to calling <a href="#parcoords_clear">parcoords.clear("highlight")</a>.
 
+<a name="parcoords_highlightColor" href="#parcoords_highlightColor">#</a> parcoords.<b>highlightColor</b>(*color*)
 
 Change coloring of the highlighted polylines. If *color* is a string, highlighted polylines will be rendered as that color. If *color* is a function, that function will be run for each data element and the polyline color will be the return value.
 If no *color* is specified, the highlighted polylines get the original coloring for foreground items.

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -666,16 +666,16 @@ function path_brushed(d, i) {
 };
 
 function path_foreground(d, i) {
-	if (__.highlightColor !== null) {
-		ctx.highlight.strokeStyle = d3.functor(__.highlightColor)(d, i);
-	} else {
-		ctx.highlight.strokeStyle = d3.functor(__.color)(d, i);
-	}
+	ctx.foreground.strokeStyle = d3.functor(__.color)(d, i);
 	return color_path(d, ctx.foreground);
 };
 
 function path_highlight(d, i) {
-  ctx.highlight.strokeStyle = d3.functor(__.color)(d, i);
+	if (__.highlightColor !== null) {
+		ctx.highlight.strokeStyle = d3.functor(__.highlightColor)(d, i)
+	} else {
+		ctx.highlight.strokeStyle = d3.functor(__.color)(d, i);
+	}
 	return color_path(d, ctx.highlight);
 };
 pc.clear = function(layer) {

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -666,7 +666,7 @@ function path_brushed(d, i) {
 };
 
 function path_foreground(d, i) {
-	ctx.foreground.strokeStyle = d3.functor(__.color)(d, i);
+  ctx.foreground.strokeStyle = d3.functor(__.color)(d, i);
 	return color_path(d, ctx.foreground);
 };
 
@@ -2349,19 +2349,13 @@ pc.resize = function() {
 };
 
 // highlight an array of data
-pc.highlight = function(data, keepHighlights) {
+pc.highlight = function(data) {
   if (arguments.length === 0) {
     return __.highlighted;
   }
 
-  if (keepHighlights == true) {
-    __.highlighted = __.highlighted.concat(data);
-  } 
-  else {
-    __.highlighted = data;
-    pc.clear("highlight");
-  }
-
+  __.highlighted = data;
+  pc.clear("highlight");
   d3.selectAll([canvas.foreground, canvas.brushed]).classed("faded", true);
   data.forEach(path_highlight);
   events.highlight.call(this, data);

--- a/src/autoscale.js
+++ b/src/autoscale.js
@@ -102,6 +102,7 @@ pc.autoscale = function() {
   ctx.brushed.scale(devicePixelRatio, devicePixelRatio);
   ctx.highlight.lineWidth = 3;
   ctx.highlight.scale(devicePixelRatio, devicePixelRatio);
+  ctx.highlight.strokeStyle = __.highlightColor;
 
   return this;
 };

--- a/src/axis.js
+++ b/src/axis.js
@@ -19,6 +19,11 @@ function flipAxisAndUpdatePCP(dimension) {
   }
 
   pc.render();
+
+  if (__.highlighted != 0) {
+    pc.highlight(__.highlighted);
+  }
+  
 }
 
 function rotateLabels() {
@@ -230,6 +235,11 @@ pc.reorderable = function() {
         delete dragging[d];
         d3.select(this).transition().attr("transform", "translate(" + xscale(d) + ")");
         pc.render();
+
+        if (__.highlighted != 0) {
+          pc.highlight(__.highlighted);
+        }
+
       }));
   flags.reorderable = true;
   return this;

--- a/src/events.js
+++ b/src/events.js
@@ -30,6 +30,9 @@ var side_effects = d3.dispatch.apply(this,d3.keys(__))
   .on("brushedColor", function (d) {
     ctx.brushed.strokeStyle = d.value;
   })
+  .on("highlightColor", function (d) {
+    ctx.highlight.strokeStyle = d.value;
+  })
   .on("width", function(d) { pc.resize(); })
   .on("height", function(d) { pc.resize(); })
   .on("margin", function(d) { pc.resize(); })

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -49,13 +49,19 @@ pc.resize = function() {
 };
 
 // highlight an array of data
-pc.highlight = function(data) {
+pc.highlight = function(data, keepHighlights) {
   if (arguments.length === 0) {
     return __.highlighted;
   }
 
-  __.highlighted = data;
-  pc.clear("highlight");
+  if (keepHighlights == true) {
+    __.highlighted = __.highlighted.concat(data);
+  } 
+  else {
+    __.highlighted = data;
+    pc.clear("highlight");
+  }
+
   d3.selectAll([canvas.foreground, canvas.brushed]).classed("faded", true);
   data.forEach(path_highlight);
   events.highlight.call(this, data);

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -49,19 +49,13 @@ pc.resize = function() {
 };
 
 // highlight an array of data
-pc.highlight = function(data, keepHighlights) {
+pc.highlight = function(data) {
   if (arguments.length === 0) {
     return __.highlighted;
   }
 
-  if (keepHighlights == true) {
-    __.highlighted = __.highlighted.concat(data);
-  } 
-  else {
-    __.highlighted = data;
-    pc.clear("highlight");
-  }
-
+  __.highlighted = data;
+  pc.clear("highlight");
   d3.selectAll([canvas.foreground, canvas.brushed]).classed("faded", true);
   data.forEach(path_highlight);
   events.highlight.call(this, data);

--- a/src/start.js
+++ b/src/start.js
@@ -15,6 +15,7 @@ d3.parcoords = function(config) {
     nullValueSeparator: "undefined", // set to "top" or "bottom"
     nullValueSeparatorPadding: { top: 8, right: 0, bottom: 8, left: 0 },
     color: "#069",
+    highlightColor: null,
     composite: "source-over",
     alpha: 0.7,
     bundlingStrength: 0.5,

--- a/src/styles.js
+++ b/src/styles.js
@@ -97,7 +97,7 @@ function path_brushed(d, i) {
 };
 
 function path_foreground(d, i) {
-	ctx.foreground.strokeStyle = d3.functor(__.color)(d, i);
+  ctx.foreground.strokeStyle = d3.functor(__.color)(d, i);
 	return color_path(d, ctx.foreground);
 };
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -97,15 +97,15 @@ function path_brushed(d, i) {
 };
 
 function path_foreground(d, i) {
-	if (__.highlightColor !== null) {
-		ctx.highlight.strokeStyle = d3.functor(__.highlightColor)(d, i);
-	} else {
-		ctx.highlight.strokeStyle = d3.functor(__.color)(d, i);
-	}
+	ctx.foreground.strokeStyle = d3.functor(__.color)(d, i);
 	return color_path(d, ctx.foreground);
 };
 
 function path_highlight(d, i) {
-  ctx.highlight.strokeStyle = d3.functor(__.color)(d, i);
+	if (__.highlightColor !== null) {
+		ctx.highlight.strokeStyle = d3.functor(__.highlightColor)(d, i)
+	} else {
+		ctx.highlight.strokeStyle = d3.functor(__.color)(d, i);
+	}
 	return color_path(d, ctx.highlight);
 };

--- a/src/styles.js
+++ b/src/styles.js
@@ -97,7 +97,11 @@ function path_brushed(d, i) {
 };
 
 function path_foreground(d, i) {
-  ctx.foreground.strokeStyle = d3.functor(__.color)(d, i);
+	if (__.highlightColor !== null) {
+		ctx.highlight.strokeStyle = d3.functor(__.highlightColor)(d, i);
+	} else {
+		ctx.highlight.strokeStyle = d3.functor(__.color)(d, i);
+	}
 	return color_path(d, ctx.foreground);
 };
 


### PR DESCRIPTION
When calling the API method parcoords.highlight(data) the polyline paths corresponding to the passed array of data get highlighted. The highlighted items get the color of the foreground items. 
There may be cases when we want to assign a different color to the highlighted items. This PR provides this functionality by adding an API method:
_parcoords.highlightColor(color)_
If color is a string, highlighted polylines will be rendered as that color. If color is a function, that function will be run for each data element and the polyline color will be the return value. 

Bug Fix:
Currently every time we reorder and flip axis the highlighted items are cleared out. This PR fixes this behavior by restoring the highlighted paths after these operations.

This PR is supporting the work for [Frac 457](https://jira.autodesk.com/browse/FRAC-538)

Reviewer:
@Dewb 